### PR TITLE
feat(fixtures): add CrewAI Research Agent fixture for lane crewai→langgraph (#1)

### DIFF
--- a/docs/fixtures/crewai/research_agent/agents.py
+++ b/docs/fixtures/crewai/research_agent/agents.py
@@ -1,0 +1,23 @@
+from crewai import Agent, Task, Crew
+from crewai_tools import FileWriterTool, SerperDevTool
+import os
+
+os.environ["OPENAI_API_KEY"] = "<your-key>"
+
+file_writer = FileWriterTool()
+serper_tool = SerperDevTool()
+
+project_analyst = Agent(
+    role="Project Analyst",
+    goal="Analyze project documents to identify risks and opportunities",
+    tools=[file_writer, serper_tool],
+    verbose=True
+)
+
+analysis_task = Task(
+    description="Analyze the given project PDF and extract key findings.",
+    expected_output="Markdown report with risks, strengths, and opportunities.",
+    agent=project_analyst
+)
+
+crew = Crew(agents=[project_analyst], tasks=[analysis_task])

--- a/docs/fixtures/crewai/research_agent/fixture.meta.yml
+++ b/docs/fixtures/crewai/research_agent/fixture.meta.yml
@@ -1,0 +1,9 @@
+name: crewai-research-agent
+lane: crewai→langgraph
+issue: 1
+stability: frozen
+purpose: Golden fixture for Agent Adapter validation
+owner: core-team
+notes:
+  - Used to test adapter parsing, config extraction, and runtime mapping.
+  - Do not mutate; create a new fixture if schema changes.

--- a/tests/fixtures/test_crewai_fixture.py
+++ b/tests/fixtures/test_crewai_fixture.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import importlib.util
+
+def test_fixture_agents_exist():
+    path = Path("fixtures/crewai/research_agent/agents.py")
+    assert path.exists(), "Fixture agents.py not found"
+
+def test_fixture_importable():
+    spec = importlib.util.spec_from_file_location("fixture_agents", "fixtures/crewai/research_agent/agents.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert hasattr(mod, "project_analyst"), "Agent 'project_analyst' missing in fixture"


### PR DESCRIPTION
### Summary
- Adds first golden fixture for Agent Adapter validation (CrewAI → LangGraph).
- Includes minimal CrewAI agent definition and metadata.

### Files Added
- docs/fixtures/crewai/research_agent/agents.py
- docs/fixtures/crewai/research_agent/fixture.meta.yml
- tests/fixtures/test_crewai_fixture.py

### Related
Closes #1