### PR TITLE
Feature/cha 6

### DIFF
--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs
 
 RUN npm install -g openclaw@latest

--- a/src/charm/adapters/openclaw.py
+++ b/src/charm/adapters/openclaw.py
@@ -79,14 +79,136 @@ class CharmOpenClawAdapter(BaseAdapter):
                 except subprocess.CalledProcessError:
                     logger.error(f"❌ [{skill_name}] Failed to install npm packages")
 
-    def _generate_openclaw_config(self) -> str:
+    def _onboard_openclaw(self, env: dict):
         """
-        Transform 'charm.yaml' into 'openclaw_config.json'.
+        Run OpenClaw onboarding if not already initialized.
+        Creates ~/.openclaw/openclaw.json with default config.
+        """
+        openclaw_home = os.path.join(env.get("HOME", "/root"), ".openclaw")
+        config_file = os.path.join(openclaw_home, "openclaw.json")
+
+        if os.path.exists(config_file):
+            return
+
+        logger.info("🔧 Running OpenClaw onboarding (first boot)...")
+        try:
+            result = subprocess.run(
+                [
+                    "openclaw", "onboard",
+                    "--non-interactive", "--accept-risk",
+                    "--workspace", self.workspace_dir,
+                ],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                logger.debug(f"Onboard stderr (non-fatal): {result.stderr.strip()}")
+            logger.info("✅ OpenClaw onboarding complete.")
+        except Exception as e:
+            logger.warning(f"Onboarding issue (may be non-fatal): {e}")
+
+    def _build_mcp_servers(self) -> dict:
+        """
+        Build MCP server configurations from charm.yaml skills.
+        Returns a dict suitable for ~/.openclaw/.mcp.json
         """
         mcp_servers = {}
         oc_config = self.config.runtime.config
 
-        # Logic for writing IDENTITY.md, adding file existence check to avoid overwriting user customizations
+        if not self.config.runtime.skills:
+            return mcp_servers
+
+        for skill in self.config.runtime.skills:
+            server_config = {}
+            is_local_path = False
+            target_path = ""
+
+            if skill.source.startswith("local:"):
+                rel_path = skill.source.replace("local:", "")
+                target_path = os.path.abspath(rel_path)
+                is_local_path = True
+            elif skill.source.startswith("git:") or skill.source.startswith("http"):
+                target_path = os.path.abspath(f"skills/{skill.name}")
+                is_local_path = True
+
+            if is_local_path:
+                if not os.path.exists(target_path):
+                    logger.warning(f"⚠️ Skill path missing: {target_path}")
+                    continue
+
+                if not oc_config or oc_config.auto_install_dependencies:
+                    self._install_dependencies(target_path)
+
+                if os.path.isfile(target_path):
+                    if target_path.endswith(".py"):
+                        server_config = {"command": "python", "args": [target_path]}
+                    elif target_path.endswith(".js"):
+                        server_config = {"command": "node", "args": [target_path]}
+                else:
+                    if os.path.exists(os.path.join(target_path, "package.json")):
+                        server_config = {
+                            "command": "npm",
+                            "args": ["start"],
+                            "cwd": target_path,
+                        }
+                    elif os.path.exists(os.path.join(target_path, "pyproject.toml")):
+                        server_config = {
+                            "command": "uv",
+                            "args": ["run", "python", "-m", "server"],
+                            "cwd": target_path,
+                        }
+                        if os.path.exists(os.path.join(target_path, "server.py")):
+                            server_config["args"] = ["run", "python", "server.py"]
+                    else:
+                        server_config = {
+                            "command": "python",
+                            "args": [os.path.join(target_path, "server.py")],
+                        }
+
+            elif skill.source.startswith("smithery:") or skill.source.startswith("npm:"):
+                pkg_name = skill.source.replace("smithery:", "").replace("npm:", "")
+                server_config = {
+                    "command": "npx",
+                    "args": [
+                        "-y",
+                        "@smithery/cli",
+                        "run",
+                        pkg_name,
+                        "--config",
+                        json.dumps(skill.config),
+                    ],
+                }
+
+            elif skill.source.startswith("pip:") or skill.source.startswith("pypi:"):
+                pkg_name = skill.source.replace("pip:", "").replace("pypi:", "")
+                server_config = {"command": "uvx", "args": [pkg_name]}
+
+            if server_config:
+                env_vars = skill.config.copy() if skill.config else {}
+                for env_key, env_value in os.environ.items():
+                    if (
+                        env_key.endswith("_API_KEY")
+                        or env_key.endswith("_ACCESS_TOKEN")
+                        or env_key.endswith("_TOKEN")
+                        or env_key in ["OPENAI_API_BASE", "OPENAI_API_HOST"]
+                    ):
+                        if env_key not in env_vars:
+                            env_vars[env_key] = env_value
+
+                if env_vars:
+                    server_config["env"] = env_vars
+
+                mcp_servers[skill.name] = server_config
+
+        return mcp_servers
+
+    def _generate_openclaw_config(self, env: dict):
+        """Configure OpenClaw for the current session."""
+        oc_config = self.config.runtime.config
+        openclaw_home = os.path.join(env.get("HOME", "/root"), ".openclaw")
+
         if oc_config and oc_config.system_prompt:
             identity_path = os.path.join(self.workspace_dir, "IDENTITY.md")
             try:
@@ -97,115 +219,34 @@ class CharmOpenClawAdapter(BaseAdapter):
             except Exception as e:
                 logger.error(f"Failed to write IDENTITY.md: {e}")
 
-        # Process Skills
-        if self.config.runtime.skills:
-            for skill in self.config.runtime.skills:
-                server_config = {}
-                is_local_path = False
-                target_path = ""
-
-                # --- Path Resolution ---
-                if skill.source.startswith("local:"):
-                    rel_path = skill.source.replace("local:", "")
-                    target_path = os.path.abspath(rel_path)
-                    is_local_path = True
-                elif skill.source.startswith("git:") or skill.source.startswith("http"):
-                    target_path = os.path.abspath(f"skills/{skill.name}")
-                    is_local_path = True
-
-                # --- Configuration Building ---
-                if is_local_path:
-                    if not os.path.exists(target_path):
-                        logger.warning(f"⚠️ Skill path missing: {target_path}")
-                        continue
-
-                    # Auto-Install Deps
-                    if not oc_config or oc_config.auto_install_dependencies:
-                        self._install_dependencies(target_path)
-
-                    # Detect Runtime
-                    if os.path.isfile(target_path):
-                        if target_path.endswith(".py"):
-                            server_config = {"command": "python", "args": [target_path]}
-                        elif target_path.endswith(".js"):
-                            server_config = {"command": "node", "args": [target_path]}
-                    else:
-                        if os.path.exists(os.path.join(target_path, "package.json")):
-                            server_config = {
-                                "command": "npm",
-                                "args": ["start"],
-                                "cwd": target_path,
-                            }
-                        elif os.path.exists(os.path.join(target_path, "pyproject.toml")):
-                            server_config = {
-                                "command": "uv",
-                                "args": ["run", "python", "-m", "server"],
-                                "cwd": target_path,
-                            }
-                            if os.path.exists(os.path.join(target_path, "server.py")):
-                                server_config["args"] = ["run", "python", "server.py"]
-                        else:
-                            server_config = {
-                                "command": "python",
-                                "args": [os.path.join(target_path, "server.py")],
-                            }
-
-                elif skill.source.startswith("smithery:") or skill.source.startswith("npm:"):
-                    pkg_name = skill.source.replace("smithery:", "").replace("npm:", "")
-                    server_config = {
-                        "command": "npx",
-                        "args": [
-                            "-y",
-                            "@smithery/cli",
-                            "run",
-                            pkg_name,
-                            "--config",
-                            json.dumps(skill.config),
-                        ],
-                    }
-
-                elif skill.source.startswith("pip:") or skill.source.startswith("pypi:"):
-                    pkg_name = skill.source.replace("pip:", "").replace("pypi:", "")
-                    server_config = {"command": "uvx", "args": [pkg_name]}
-
-                # --- Environment Injection ---
-                if server_config:
-                    env_vars = skill.config.copy() if skill.config else {}
-                    for env_key, env_value in os.environ.items():
-                        if (
-                            env_key.endswith("_API_KEY")
-                            or env_key.endswith("_ACCESS_TOKEN")
-                            or env_key.endswith("_TOKEN")
-                            or env_key in ["OPENAI_API_BASE", "OPENAI_API_HOST"]
-                        ):
-                            if env_key not in env_vars:
-                                env_vars[env_key] = env_value
-
-                    if env_vars:
-                        server_config["env"] = env_vars
-
-                    mcp_servers[skill.name] = server_config
-
-        # Restore LLM parameter assembly
-        full_config = {
-            "mcpServers": mcp_servers,
-            "workspace": self.workspace_dir,
-            "llm": {
-                "model": oc_config.model if oc_config else "gpt-4o",
-                "temperature": oc_config.temperature if oc_config else 0.0,
-            },
-        }
-
-        config_path = os.path.join(self.work_dir, "openclaw_runtime_config.json")
+        mcp_servers = self._build_mcp_servers()
+        mcp_json_path = os.path.join(openclaw_home, ".mcp.json")
         try:
-            with open(config_path, "w", encoding="utf-8") as f:
-                json.dump(full_config, f, indent=2)
-            logger.info(f"Generated OpenClaw Config: {config_path}")
+            os.makedirs(openclaw_home, exist_ok=True)
+            with open(mcp_json_path, "w", encoding="utf-8") as f:
+                json.dump(mcp_servers, f, indent=2)
+            logger.info(f"📋 MCP config written: {mcp_json_path} ({len(mcp_servers)} servers)")
         except Exception as e:
-            logger.error(f"Failed to write config: {e}")
+            logger.error(f"Failed to write .mcp.json: {e}")
             raise e
 
-        return config_path
+        model = oc_config.model if oc_config else "gpt-4o"
+        if "/" not in model:
+            if os.environ.get("ANTHROPIC_API_KEY"):
+                model = f"anthropic/{model}"
+            elif os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY"):
+                model = f"google/{model}"
+            else:
+                model = f"openai/{model}"
+            logger.info(f"🏷️ Auto-prefixed model to: {model}")
+        try:
+            subprocess.run(
+                ["openclaw", "config", "set", "agents.defaults.model", model],
+                env=env, capture_output=True, text=True, timeout=10,
+            )
+            logger.info(f"🤖 Model set to: {model}")
+        except Exception as e:
+            logger.warning(f"Failed to set model config: {e}")
 
     def _parse_log(self, line: str):
         """Parse OpenClaw stdout to Charm Events."""
@@ -236,7 +277,9 @@ class CharmOpenClawAdapter(BaseAdapter):
     ) -> Dict[str, Any]:
         logger.info("🚀 Booting OpenClaw Adapter (Session Mode)")
 
-        # 1. Copy initial templates (with non-overwriting mechanism)
+        env = os.environ.copy()
+        env["HOME"] = "/root"
+
         try:
             for item in os.listdir(self.work_dir):
                 if item in ["openclaw_runtime_config.json", "input.json"]:
@@ -255,10 +298,9 @@ class CharmOpenClawAdapter(BaseAdapter):
         except Exception as e:
             logger.error(f"Failed to sync static assets: {e}")
 
-        # 2. Config Generation
-        config_path = self._generate_openclaw_config()
+        self._onboard_openclaw(env)
+        self._generate_openclaw_config(env)
 
-        # 3. Prepare Prompt (Normal or Upgrade Mode)
         if "__charm_upgrade_diff__" in inputs:
             upgrade_diff = inputs.pop("__charm_upgrade_diff__")
 
@@ -271,22 +313,23 @@ class CharmOpenClawAdapter(BaseAdapter):
                 )
             except Exception as e:
                 logger.error(f"Failed to load upgrade template: {e}")
-                template_str = "Execute upgrade with diff: {upgrade_diff}"  # Fallback
+                template_str = "Execute upgrade with diff: {upgrade_diff}"
 
             user_input = template_str.format(upgrade_diff=upgrade_diff)
             logger.info("🔧 Upgrade payload intercepted. Launching Agentic Merge Mode.")
         else:
             user_input = inputs.get("input", "")
-            # Filter out underlying system parameters to avoid interfering with AI
             for k, v in inputs.items():
                 if k not in ["input", "__charm_thread_id__", "__charm_state__"]:
                     user_input += f"\n\n[{k}]: {v}"
 
-        # 4. Start OpenClaw CLI
-        cmd = ["openclaw", "run", "--config", config_path, "--prompt", user_input]
-
-        env = os.environ.copy()
-        env["HOME"] = "/root"
+        cmd = [
+            "openclaw", "agent",
+            "--local",
+            "--agent", "main",
+            "--message", user_input,
+            "--json",
+        ]
 
         try:
             process = subprocess.Popen(
@@ -303,15 +346,16 @@ class CharmOpenClawAdapter(BaseAdapter):
                 "message": "OpenClaw binary not found. Is it installed in the Docker image?",
             }
 
-        # Ensure stdout collection array exists, used as fallback for Final Answer
         stdout_lines = []
+        stderr_lines = []
         final_output = ""
 
-        # Define Stream Reader
         def read_stream(stream, is_stderr):
             nonlocal final_output
             for line in stream:
-                if not is_stderr:
+                if is_stderr:
+                    stderr_lines.append(line.strip())
+                else:
                     if "Final Answer:" in line:
                         final_output = line.split("Final Answer:", 1)[1].strip()
                     else:
@@ -330,15 +374,22 @@ class CharmOpenClawAdapter(BaseAdapter):
         t_err.join()
 
         if process.returncode != 0:
-            return {"status": "error", "message": f"OpenClaw exited with code {process.returncode}"}
+            err_detail = "\n".join(stderr_lines[-20:]) if stderr_lines else "No stderr captured."
+            logger.error(f"OpenClaw stderr:\n{err_detail}")
+            return {"status": "error", "message": f"OpenClaw exited with code {process.returncode}\n{err_detail}"}
 
-        # If Agent forgot to output Final Answer, backtrack and extract from log array
         if not final_output and stdout_lines:
-            clean_output = [
-                line for line in stdout_lines if not line.startswith("[") and "Thought:" not in line
-            ]
-            if clean_output:
-                final_output = "\n".join(clean_output[-10:])
+            raw_output = "".join(stdout_lines).strip()
+            try:
+                result_json = json.loads(raw_output)
+                final_output = result_json.get("reply", result_json.get("output", raw_output))
+            except (json.JSONDecodeError, TypeError):
+                clean_output = [
+                    line for line in stdout_lines
+                    if not line.startswith("[") and "Thought:" not in line
+                ]
+                if clean_output:
+                    final_output = "\n".join(clean_output[-10:])
 
         return {
             "status": "success",

--- a/src/charm/adapters/openclaw.py
+++ b/src/charm/adapters/openclaw.py
@@ -90,7 +90,7 @@ class CharmOpenClawAdapter(BaseAdapter):
         if os.path.exists(config_file):
             return
 
-        logger.info("🔧 Running OpenClaw onboarding (first boot)...")
+        logger.info("Running OpenClaw onboarding (first boot)...")
         try:
             result = subprocess.run(
                 [
@@ -105,7 +105,7 @@ class CharmOpenClawAdapter(BaseAdapter):
             )
             if result.returncode != 0:
                 logger.debug(f"Onboard stderr (non-fatal): {result.stderr.strip()}")
-            logger.info("✅ OpenClaw onboarding complete.")
+            logger.info("OpenClaw onboarding complete.")
         except Exception as e:
             logger.warning(f"Onboarding issue (may be non-fatal): {e}")
 
@@ -135,7 +135,7 @@ class CharmOpenClawAdapter(BaseAdapter):
 
             if is_local_path:
                 if not os.path.exists(target_path):
-                    logger.warning(f"⚠️ Skill path missing: {target_path}")
+                    logger.warning(f"Skill path missing: {target_path}")
                     continue
 
                 if not oc_config or oc_config.auto_install_dependencies:
@@ -225,7 +225,7 @@ class CharmOpenClawAdapter(BaseAdapter):
             os.makedirs(openclaw_home, exist_ok=True)
             with open(mcp_json_path, "w", encoding="utf-8") as f:
                 json.dump(mcp_servers, f, indent=2)
-            logger.info(f"📋 MCP config written: {mcp_json_path} ({len(mcp_servers)} servers)")
+            logger.info(f"MCP config written: {mcp_json_path} ({len(mcp_servers)} servers)")
         except Exception as e:
             logger.error(f"Failed to write .mcp.json: {e}")
             raise e
@@ -238,13 +238,13 @@ class CharmOpenClawAdapter(BaseAdapter):
                 model = f"google/{model}"
             else:
                 model = f"openai/{model}"
-            logger.info(f"🏷️ Auto-prefixed model to: {model}")
+            logger.info(f"Auto-prefixed model to: {model}")
         try:
             subprocess.run(
                 ["openclaw", "config", "set", "agents.defaults.model", model],
                 env=env, capture_output=True, text=True, timeout=10,
             )
-            logger.info(f"🤖 Model set to: {model}")
+            logger.info(f"Model set to: {model}")
         except Exception as e:
             logger.warning(f"Failed to set model config: {e}")
 

--- a/src/charm/cli/commands/run.py
+++ b/src/charm/cli/commands/run.py
@@ -47,9 +47,32 @@ async def run_docker_simulation(path: str, payload: Dict[str, Any], env_vars: Di
     executor = CharmDockerExecutor()
     abs_path = os.path.abspath(path)
 
+    # Detect adapter type and skills from charm.yaml for image selection
+    adapter_type = "python"
+    skills = []
+    try:
+        import yaml
+
+        charm_yaml_path = os.path.join(abs_path, "charm.yaml")
+        if os.path.exists(charm_yaml_path):
+            with open(charm_yaml_path, "r") as f:
+                uac = yaml.safe_load(f)
+            runtime = uac.get("runtime", {})
+            adapter_cfg = runtime.get("adapter", {})
+            adapter_type = adapter_cfg.get("type", "python")
+            skills = runtime.get("skills", [])
+    except Exception:
+        pass
+
+    # Select correct Docker image based on adapter type
+    image = None
+    if adapter_type in ("openclaw", "node"):
+        image = "ucmind/runner-full:latest"
+
     console.print(
         Panel(
-            f"Mounting: [cyan]{abs_path}[/cyan]\nEnvironment: [cyan]{len(env_vars)} variables[/cyan]",
+            f"Mounting: [cyan]{abs_path}[/cyan]\nEnvironment: [cyan]{len(env_vars)} variables[/cyan]"
+            + (f"\nImage: [cyan]{image or 'ucmind/runner-base:latest'}[/cyan]" if image else ""),
             title="[bold blue]🚀 Starting Docker Simulation[/bold blue]",
             border_style="blue",
         )
@@ -64,6 +87,9 @@ async def run_docker_simulation(path: str, payload: Dict[str, Any], env_vars: Di
             file_urls={},
             history=[],
             local_source_path=abs_path,  # Mount local path
+            image=image,
+            adapter_type=adapter_type,
+            skills=skills,
         ):
             parse_and_print_sse(sse_line)
 

--- a/src/charm/runner/backend/base.py
+++ b/src/charm/runner/backend/base.py
@@ -15,6 +15,7 @@ class RunConfig(BaseModel):
     host_artifact_path: str
     host_cache_dir: str
     local_source_path: Optional[str] = None
+    local_sdk_path: Optional[str] = None  # Host path to the SDK repo, mounted at /mnt/local_sdk
     bundle_local_path: Optional[str] = None  # When set (e.g. local dev), container uses file instead of curl
     image: Optional[str] = None
     lifecycle: str = "serverless"

--- a/src/charm/runner/backend/cloud_run.py
+++ b/src/charm/runner/backend/cloud_run.py
@@ -1,12 +1,9 @@
 import asyncio
+import base64
+import functools
 import logging
 import os
-import json
-import time
-import base64
-import uuid
-import functools
-from typing import AsyncGenerator, Dict, Any
+from typing import AsyncGenerator, Dict
 
 try:
     from google.cloud import run_v2
@@ -18,13 +15,16 @@ except ImportError:
 
 from ...core.io import EVENT_PREFIX
 from ...runner.protocol import sse_pack
-from ...runner.utils import clean_log_fallback, is_duplicate_log
+from ...runner.utils import clean_log_fallback
 from .base import ExecutionBackend, RunConfig
 
 logger = logging.getLogger("charm.runner.cloud_run")
 
 
 class CloudRunBackend(ExecutionBackend):
+
+    _job_cache: Dict[str, str] = {}
+
     def __init__(self):
         if not run_v2 or not cloud_logging:
             raise RuntimeError(
@@ -42,41 +42,51 @@ class CloudRunBackend(ExecutionBackend):
         self.parent = f"projects/{self.project_id}/locations/{self.region}"
         self.storage_bucket = os.getenv("CHARM_USER_BUCKET_NAME")
 
-    async def _create_job(self, job_id: str, config: RunConfig) -> str:
-        b64_script = base64.b64encode(config.script_content.encode("utf-8")).decode("utf-8")
+    def _make_job_id(self, agent_id: str) -> str:
+        safe = agent_id.replace("_", "-").lower()[:40]
+        return f"charm-{safe}"
 
-        env_vars = [
-            {"name": "PYTHONUNBUFFERED", "value": "1"},
-            {"name": "CHARM_BOOTSTRAP_SCRIPT", "value": b64_script},
-            *[{"name": k, "value": str(v)} for k, v in config.env_vars.items() if v is not None],
-        ]
+    async def _get_or_create_job(self, config: RunConfig) -> str:
+        job_id = self._make_job_id(config.agent_id)
+        job_fqn = f"{self.parent}/jobs/{job_id}"
+
+        if job_fqn in self._job_cache:
+            logger.info(f"[CloudRun] Reusing cached job: {job_id}")
+            return self._job_cache[job_fqn]
+
+        try:
+            request = run_v2.GetJobRequest(name=job_fqn)
+            existing = await self.jobs_client.get_job(request=request)
+            logger.info(f"[CloudRun] Found existing job: {job_id}")
+            self._job_cache[job_fqn] = existing.name
+            return existing.name
+        except google_exceptions.NotFound:
+            logger.info(f"[CloudRun] Job {job_id} not found, creating...")
 
         default_fallback = (
             "us-central1-docker.pkg.dev/charm-cloud-runner/charm/runner-standard:latest"
         )
         worker_image = config.image or os.getenv("CHARM_WORKER_IMAGE", default_fallback)
-
-        logger.info(f"[CloudRun] Target Image resolved to: {worker_image}")
-
-        logger.info(f"[CloudRun] Creating Serverless Task Job {job_id}")
+        logger.info(f"[CloudRun] Target Image: {worker_image}")
 
         container = {
             "image": worker_image,
             "command": ["/bin/bash", "-c"],
             "args": ["echo $CHARM_BOOTSTRAP_SCRIPT | base64 -d | bash"],
-            "env": env_vars,
+            "env": [
+                {"name": "PYTHONUNBUFFERED", "value": "1"},
+                {"name": "CHARM_BOOTSTRAP_SCRIPT", "value": "ZWNobyAncmVhZHkn"},
+            ],
             "resources": {
                 "limits": {
-                    "memory": "1Gi",
-                    "cpu": "1000m",
+                    "memory": "2Gi",
+                    "cpu": "2000m",
                 }
             },
         }
 
         job = run_v2.Job()
         job.template.template.max_retries = 0
-
-        # Serverless hard limit: 10 minutes (regardless of adapter type)
         job.template.template.timeout = "600s"
 
         if self.storage_bucket:
@@ -91,10 +101,11 @@ class CloudRunBackend(ExecutionBackend):
         job.template.template.containers = [container]
 
         request = run_v2.CreateJobRequest(parent=self.parent, job=job, job_id=job_id)
-
         operation = await self.jobs_client.create_job(request=request)
         logger.info(f"[CloudRun] Creating Job {job_id} using image {worker_image}...")
         result = await operation.result()
+
+        self._job_cache[job_fqn] = result.name
         return result.name
 
     async def _fetch_logs_sync(self, filter_str):
@@ -106,25 +117,40 @@ class CloudRunBackend(ExecutionBackend):
         return sorted(list(entries), key=lambda x: x.timestamp)
 
     async def stream_logs(self, config: RunConfig) -> AsyncGenerator[str, None]:
-        safe_agent_id = config.agent_id.replace("_", "-").lower()[:20]
-        job_id = f"charm-{safe_agent_id}-{uuid.uuid4().hex[:6]}"
         job_name = ""
 
         try:
             yield sse_pack("status", "Provisioning Cloud Sandbox...")
-            job_name = await self._create_job(job_id, config)
+            job_name = await self._get_or_create_job(config)
+
+            b64_script = base64.b64encode(config.script_content.encode("utf-8")).decode("utf-8")
+            env_overrides = [
+                run_v2.EnvVar(name="PYTHONUNBUFFERED", value="1"),
+                run_v2.EnvVar(name="CHARM_BOOTSTRAP_SCRIPT", value=b64_script),
+                *[
+                    run_v2.EnvVar(name=k, value=str(v))
+                    for k, v in config.env_vars.items()
+                    if v is not None
+                ],
+            ]
 
             yield sse_pack("status", "Starting Execution Environment...")
-            run_request = run_v2.RunJobRequest(name=job_name)
+            run_request = run_v2.RunJobRequest(
+                name=job_name,
+                overrides=run_v2.RunJobRequest.Overrides(
+                    container_overrides=[
+                        run_v2.RunJobRequest.Overrides.ContainerOverride(
+                            env=env_overrides,
+                        )
+                    ],
+                ),
+            )
             operation = await self.jobs_client.run_job(request=run_request)
 
             execution_name = operation.metadata.name
-            execution_id = execution_name.split("/")[-1]  # e.g. charm-2247afda-4665-4a01-b-0cba9b-cg7nt
+            execution_id = execution_name.split("/")[-1]
             logger.info(f"[CloudRun] Tailing logs for execution: {execution_name}")
 
-            # Fetch logs from the Job *container* (script stdout/stderr), not the Runner API.
-            # In GCP: Cloud Run > Jobs > <job> > Executions > <execution> > LOGS, or
-            # Logs Explorer: resource.type="cloud_run_job" + label run.googleapis.com/execution_name=<execution_id>
             filter_str = f"""
             resource.type="cloud_run_job"
             labels."run.googleapis.com/execution_name"="{execution_id}"
@@ -185,12 +211,10 @@ class CloudRunBackend(ExecutionBackend):
                                     yield sse_pack("error", f"System: {line}\n")
 
                 if not is_done:
-                    await asyncio.sleep(2)
+                    await asyncio.sleep(1)
 
-            # Drain trailing logs: Cloud Logging can delay a few seconds, so the "final" event
-            # may appear after operation.done(). Fetch a few more times before closing the stream.
-            for _ in range(3):
-                await asyncio.sleep(2)
+            for _ in range(2):
+                await asyncio.sleep(1)
                 try:
                     tail_logs = await loop.run_in_executor(
                         None,
@@ -257,17 +281,22 @@ class CloudRunBackend(ExecutionBackend):
 
         finally:
             if job_name:
-                skip_cleanup = os.environ.get("CHARM_KEEP_JOB_AFTER_RUN", "").lower() in ("1", "true", "yes")
-                if skip_cleanup:
-                    logger.info(f"[CloudRun] Keeping job for inspection: {job_name}")
-                else:
+                force_delete = os.environ.get("CHARM_DELETE_JOB_AFTER_RUN", "").lower() in ("1", "true", "yes")
+                if force_delete:
                     yield sse_pack("status", "Cleaning up resources...")
                     await self.cleanup(job_name)
+                else:
+                    logger.info(f"[CloudRun] Keeping job for reuse: {job_name}")
 
-    async def cleanup(self, job_name: str):
+    async def cleanup(self, job_name_or_run_id: str):
+        if "/jobs/" not in job_name_or_run_id:
+            logger.debug(f"[CloudRun] cleanup called with run_id {job_name_or_run_id}, skipping (job reuse)")
+            return
+
         try:
-            request = run_v2.DeleteJobRequest(name=job_name)
+            request = run_v2.DeleteJobRequest(name=job_name_or_run_id)
             await self.jobs_client.delete_job(request=request)
-            logger.info(f"[CloudRun] Deleted job {job_name}")
+            self._job_cache.pop(job_name_or_run_id, None)
+            logger.info(f"[CloudRun] Deleted job {job_name_or_run_id}")
         except Exception as e:
-            logger.warning(f"[CloudRun] Failed to delete job {job_name}: {e}")
+            logger.warning(f"[CloudRun] Failed to delete job {job_name_or_run_id}: {e}")

--- a/src/charm/runner/backend/docker.py
+++ b/src/charm/runner/backend/docker.py
@@ -90,6 +90,13 @@ class DockerBackend(ExecutionBackend):
                 "mode": "ro",
             }
 
+        # Mount local SDK for dev installs (LOCAL_SDK_HOST_PATH)
+        if config.local_sdk_path and os.path.isdir(config.local_sdk_path):
+            volumes_config[config.local_sdk_path] = {
+                "bind": "/mnt/local_sdk",
+                "mode": "ro",
+            }
+
         if config.bundle_local_path:
             _mount_dir = os.path.dirname(config.bundle_local_path)
             volumes_config[_mount_dir] = {"bind": "/app/bundle_mount", "mode": "ro"}

--- a/src/charm/runner/executor.py
+++ b/src/charm/runner/executor.py
@@ -244,7 +244,9 @@ class CharmDockerExecutor:
             install_local_sdk_cmd = f"""
             if [ -d "/mnt/local_sdk" ]; then
                 echo '{EVENT_PREFIX}{{"type":"status","content":"[DEV] Installing Local SDK..."}}'
-                uv pip install -e /mnt/local_sdk
+                cp -r /mnt/local_sdk /tmp/_local_sdk
+                uv pip install /tmp/_local_sdk
+                rm -rf /tmp/_local_sdk
             fi
             """
 
@@ -617,6 +619,7 @@ class CharmDockerExecutor:
             host_artifact_path=host_artifact_path,
             host_cache_dir=HOST_CACHE_DIR,
             local_source_path=local_source_path if should_mount_local else None,
+            local_sdk_path=local_sdk_path if should_mount_local else None,
             bundle_local_path=bundle_local_path if use_bundle_local else None,
             image=image,
             lifecycle=lifecycle,


### PR DESCRIPTION
1. Node.js upgraded to v22: Changed Dockerfile.full from setup_20.x → setup_22.x
2. Added _onboard_openclaw() method: Runs openclaw onboard --non-interactive --accept-risk on first boot to create ~/.openclaw/openclaw.json before the agent is invoked
3. Extracted _build_mcp_servers() into its own method: Moved MCP server config building (local, pip, npm, smithery, git sources) out of _generate_openclaw_config() for clarity
4. MCP config now written to ~/.openclaw/.mcp.json: Instead of generating a standalone openclaw_runtime_config.json, skills are written directly to OpenClaw's native .mcp.json location
5. Auto-prefix model provider: If the model name in charm.yaml has no / prefix, it auto-detects the provider from available API keys (ANTHROPIC_API_KEY → anthropic/, GOOGLE_API_KEY → google/, else openai/) and sets it via openclaw config set
6. Switched CLI command from openclaw run to openclaw agent: Now uses openclaw agent --local --agent main --message <prompt> --json instead of the old openclaw run --config <path> --prompt <prompt>
7. JSON output parsing: Final output is now parsed as JSON first (result.reply or result.output), falling back to the old line-based extraction
8. stderr capture and error reporting: Added stderr_lines collection and includes the last 20 stderr lines in the error message when OpenClaw exits non-zero
9. Docker image auto-selection in charm run --docker: Reads adapter.type from charm.yaml; uses ucmind/runner-full:latest for openclaw or node adapters instead of the base image
10. RunConfig.local_sdk_path added: New optional field on  RunConfig to mount the local SDK repo into the container at /mnt/local_sdk
11. Docker backend mounts local SDK: Added volume mount for local_sdk_path in DockerBackend
12. Local SDK install fix: Changed from uv pip install -e /mnt/local_sdk (editable, read-only mount conflict) to copying to /tmp/_local_sdk first, then installing, then cleaning up
13. Executor passes local_sdk_path to  RunConfig when running in local dev mode