### PR TITLE
fix: sync develop with main and resolve documentation conflicts

### DIFF
--- a/docs/adapters/overview.mdx
+++ b/docs/adapters/overview.mdx
@@ -32,6 +32,10 @@ runtime:
 - Use `langchain`, `langgraph`, or `crewai` when you already use that framework.
 - Use `openclaw` for browser, tools, and computer-use style workflows.
 
+## Third-party adapter plugins
+
+Any pip package can register additional `runtime.adapter.type` values via `[project.entry-points."charm.adapters"]`. These require a [custom runtime image](/guides/custom-runtimes) on the cloud runner. See [Extensibility Overview](/guides/extensibility) and [Custom Adapters](/guides/custom-adapters).
+
 ## Adapter Pages
 
 - [Custom](/adapters/custom)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -109,6 +109,7 @@
                     {
                         "group": "Customization",
                         "pages": [
+                            "guides/extensibility",
                             "guides/custom-runtimes",
                             "guides/custom-adapters",
                             "guides/telemetry-exporters",

--- a/docs/guides/community-templates.mdx
+++ b/docs/guides/community-templates.mdx
@@ -1,59 +1,82 @@
 ---
 title: Community Templates
-description: Learn how to contribute custom agent templates to the Charm ecosystem.
+description: Contribute starter agent templates to the Charm CLI scaffold registry.
 ---
 
 # Community Templates
 
-Charm's CLI scaffold system (`charm init`) is completely decoupled from the SDK's release cycle. This means the community can easily contribute new agent templates, and they will be instantly available to all developers worldwide without requiring an SDK update.
+`charm init` scaffolds new agents from a remote manifest — not from files bundled inside the installed `charmos` wheel. That lets the community add templates without waiting for an SDK release.
 
 ## How it works
 
-When you run `charm init`, the CLI fetches the latest [templates-manifest.json](https://github.com/CharmAIOS/Charm/blob/main/templates-manifest.json) from the `main` branch of the Charm repository. This JSON file acts as a central registry containing all the files and configurations for every template.
+When you run `charm init`, the CLI fetches:
 
-## Contributing a Template
+```
+https://raw.githubusercontent.com/charmaios/charm/main/templates-manifest.json
+```
 
-If you have built an excellent starter template (e.g., a "Sales Agent" or "Next.js Integration Agent"), you can share it by submitting a Pull Request to the Charm GitHub repository.
+Each manifest entry lists files (as JSON strings) to write into the new project directory. After a PR merges to **`main`**, the template is available globally on the next `charm init`.
 
-You **do not** need to write any Python code to add a template!
+Offline fallback: if the manifest cannot be fetched, the CLI scaffolds a minimal Python template.
 
-### Step 1: Prepare your JSON entry
-Create a JSON object that describes your template and contains all the initial files you want to scaffold. 
+## Contributing a template
 
-Here is the schema for a single template entry:
+You **do not** write Python loader code — only a JSON entry in the manifest.
+
+### Step 1: Prepare your template entry
 
 ```json
 {
   "id": "my-sales-agent",
-  "description": "An autonomous sales agent with Salesforce integration.",
-  "post_init_message": "  ├── charm.yaml\n  ├── .charmignore\n  └── src/\n      └── main.py\n\nNext: run 'charm push'!",
+  "description": "Sales outreach agent starter",
+  "post_init_message": "  ├── charm.yaml\n  ├── .charmignore\n  └── src/\n      └── main.py\n\nNext: charm push",
   "files": [
     {
       "path": "charm.yaml",
-      "content": "persona:\n  name: \"my-agent\"\n  description: \"A sales agent.\"\nruntime:\n  adapter:\n    type: python\n    entry_point: src.main:agent\n"
+      "content": "version: \"0.4.2\"\n\npersona:\n  name: \"My Sales Agent\"\n  description: \"A sales agent starter.\"\n  version: \"0.1.0\"\n\ninterface:\n  input:\n    type: object\n    required: [message]\n    properties:\n      message: { type: string, title: Message }\n  output:\n    type: string\n\nruntime:\n  adapter:\n    type: custom\n    entry_point: src.main:agent\n  lifecycle: serverless\n"
     },
     {
       "path": ".charmignore",
-      "content": ".env\n__pycache__/\n"
+      "content": ".env\n.venv\n__pycache__/\n*.pyc\n"
+    },
+    {
+      "path": "src/__init__.py",
+      "content": ""
     },
     {
       "path": "src/main.py",
-      "content": "# Your agent logic here\ndef agent(inputs):\n    return 'Hello Sales!'"
+      "content": "def agent(inputs):\n    msg = inputs.get('message', 'hello')\n    return f'Sales draft for: {msg}'\n"
     }
   ]
 }
 ```
 
 **Tips:**
-- The `id` must be unique and use `kebab-case`. This is the ID users will type in `charm init --template <id>`.
-- Keep the `description` concise (under 60 characters).
-- Include `charm.yaml` and `.charmignore` in the `files` array. The CLI will automatically inject the user's chosen agent name into `charm.yaml`.
-- Ensure your file `content` strings are properly escaped (e.g., escaping newlines as `\n` and quotes as `\"`).
 
-### Step 2: Submit a Pull Request
-1. Fork the [CharmAIOS/Charm](https://github.com/CharmAIOS/Charm) repository.
-2. Edit the `templates-manifest.json` file in the root directory.
-3. Append your new template object to the `templates` array.
-4. Submit a Pull Request.
+- `id` must be unique **kebab-case** — used as `charm init my-agent --template my-sales-agent`
+- Include `version: "0.4.2"` in `charm.yaml` content (required contract version)
+- Use `type: custom` (or `python`, an alias) for standard Python agents — not a fictional adapter name unless you document a required plugin
+- Escape newlines as `\n` and quotes as `\"` inside JSON strings
+- Rich templates can include `interface.ui` for Store widgets — see [Input Forms](/guides/interface)
 
-Once your PR is reviewed and merged into `main`, your template will immediately be live! Anyone running `charm init` will see your template in the interactive menu.
+### Step 2: Open a pull request
+
+1. Fork [CharmAIOS/Charm](https://github.com/CharmAIOS/Charm)
+2. Append your object to the `templates` array in root `templates-manifest.json`
+3. Submit a PR for review
+
+After merge to `main`, your template appears in `charm init` (interactive menu or `--template <id>`).
+
+## Templates vs runtime plugins
+
+| | Community template | Adapter plugin |
+|---|-------------------|----------------|
+| Delivers | Starter files for `charm init` | New `runtime.adapter.type` |
+| Registration | Manifest PR | `charm.adapters` entry point |
+| Custom Docker image | Only if template's `charm.yaml` sets `custom_image` | Required on cloud |
+
+## Related
+
+- [Extensibility Overview](/guides/extensibility)
+- [Build Your First Agent](/quickstart/first-app)
+- [Configuration](/guides/manifest)

--- a/docs/guides/custom-adapters.mdx
+++ b/docs/guides/custom-adapters.mdx
@@ -1,90 +1,142 @@
 ---
 title: Custom Adapters
-description: Learn how to build and register a custom framework adapter for the Charm platform.
+description: Build and register a third-party framework adapter using Python entry points.
 ---
 
 # Custom Adapters
 
-Charm is designed to be highly pluggable. While it ships with built-in adapters for LangChain, CrewAI, and OpenClaw, you can easily integrate any Python-based AI framework by building a **Custom Adapter**.
+Use this guide when you are a **plugin author** integrating a new Python framework (AG2, AutoGen, an internal runtime, etc.) — not when you only need a plain Python function agent.
 
-Under the hood, Charm uses standard Python `entry_points` to dynamically discover and load adapters. 
+> **Using plain Python only?** You probably want the built-in **`custom`** adapter from `charm init --template python`. See [Custom Python Adapter](/adapters/custom). This guide is for registering a **new adapter name** via entry points.
 
-## 1. Create your Adapter Class
+## How discovery works
 
-Your adapter must inherit from `charm.adapters.base.BaseAdapter` and implement the `invoke` method.
+Charm loads adapters from Python **`entry_points`** in the `charm.adapters` group. The name you register becomes a valid `runtime.adapter.type` in `charm.yaml`.
 
-Create a file named `my_adapter.py`:
+Official adapters (`langchain`, `crewai`, `openclaw`, `custom`, …) use the same mechanism in the `charmos` package. Third-party packages add more names without forking core.
+
+## 1. Start from an agent project
+
+```bash
+charm init my-ag2-agent --template python
+cd my-ag2-agent
+```
+
+This scaffolds `charm.yaml`, `src/main.py`, and `.charmignore`. You will add a **separate installable package** (or a `pyproject.toml` in the same repo) for the adapter plugin.
+
+## 2. Implement `BaseAdapter`
+
+Your class must inherit from `charm.adapters.base.BaseAdapter` and implement `invoke`.
 
 ```python
-from typing import Dict, Any, Optional, List
+from typing import Any, Dict, List, Optional
 from charm.adapters.base import BaseAdapter
 
-class MyCustomAdapter(BaseAdapter):
-    def __init__(self, agent_instance: Any, **kwargs):
-        # agent_instance is the object imported from the user's entry_point
-        super().__init__(agent_instance)
-        
-    def invoke(self, inputs: Dict[str, Any], callbacks: Optional[List[Any]] = None) -> Dict[str, Any]:
-        """
-        Execute the agent logic.
-        """
-        # Execute your custom framework's logic
+class Ag2Adapter(BaseAdapter):
+    def invoke(
+        self, inputs: Dict[str, Any], callbacks: Optional[List[Any]] = None
+    ) -> Dict[str, Any]:
+        # self.agent is the object imported from runtime.adapter.entry_point
         result = self.agent.run(**inputs)
-        
         return {
             "status": "success",
-            "output": result
+            "output": result,
         }
 ```
 
-## 2. Register via Entry Points
+The loader constructs your adapter as `AdapterClass(agent_instance=..., config=...)` after importing the user's entry point from `charm.yaml`.
 
-To let Charm's core loader find your adapter, register it in your package's `pyproject.toml` under the `charm.adapters` group. 
+Return a dict with `"status": "success"` and `"output"` for standard Store rendering, or include structured keys like `_charm_render_type` (see [Output Renderers](/guides/output-renderers)).
 
-For example, if you are publishing a package called `charm-adapter-ag2`:
+## 3. Register via entry points
+
+In your plugin package's `pyproject.toml`:
 
 ```toml
+[project]
+name = "charm-adapter-ag2"
+version = "0.1.0"
+dependencies = ["charmos"]
+
 [project.entry-points."charm.adapters"]
-ag2 = "charm_adapter_ag2.adapter:MyCustomAdapter"
+ag2 = "charm_adapter_ag2.adapter:Ag2Adapter"
 ```
 
-Once a user runs `pip install charm-adapter-ag2`, the `ag2` adapter immediately becomes available to the Charm CLI and Cloud Runner.
+Install locally while developing:
 
-## 3. Use it in `charm.yaml`
+```bash
+pip install -e ./path/to/charm-adapter-ag2
+pip install -e ./path/to/my-ag2-agent   # if separate
+```
 
-Users can now reference your adapter in their `charm.yaml` file using the name you defined in the entry point (`ag2`):
+Verify discovery:
+
+```bash
+python -c "from importlib.metadata import entry_points; print([e.name for e in entry_points(group='charm.adapters')])"
+```
+
+`charm validate` should accept `runtime.adapter.type: ag2` after your package is installed.
+
+## 4. Configure `charm.yaml`
+
+```yaml
+version: "0.4.2"
+
+persona:
+  name: "My AG2 Agent"
+  description: "Agent using a third-party adapter plugin"
+  version: "0.1.0"
+
+interface:
+  input:
+    type: object
+    required: [message]
+    properties:
+      message: { type: string }
+  output:
+    type: string
+
+runtime:
+  adapter:
+    type: ag2
+    entry_point: src.main:my_agent
+  lifecycle: serverless
+```
+
+## 5. Cloud execution requires a custom image
+
+The cloud runner **does not install your plugin package at runtime**. For production:
+
+1. Build a Docker image based on [charm-base](https://github.com/CharmAIOS/Charm/pkgs/container/charm-base) or an official runner image
+2. `RUN uv pip install charm-adapter-ag2` (or `pip install`) inside the Dockerfile
+3. Set `runtime.custom_image` to the pushed image URI
 
 ```yaml
 runtime:
+  custom_image: "ghcr.io/your-org/my-ag2-runtime:prod"
   adapter:
     type: ag2
     entry_point: src.main:my_agent
 ```
 
-## 4. Running in the Cloud Runner
+See [Custom Runtimes](/guides/custom-runtimes) for registry and IAM notes.
 
-If you want to run this custom adapter in the Charm Cloud Runner, you must pair it with a **Custom Runtime** (Base Image) that has your adapter package installed.
+## Local testing
 
-Create a `Dockerfile`:
+```bash
+# Validates adapter type (plugin must be installed in local env)
+charm validate .
 
-```dockerfile
-FROM ghcr.io/charmaios/charm-base:latest
+# Runs agent logic locally (uses local env, not necessarily your custom image)
+charm run . --input "hello"
 
-# Install your custom adapter
-RUN uv pip install charm-adapter-ag2
-
-# Copy the user's agent code
-COPY . /app
+# Simulates cloud container (uses custom_image from charm.yaml)
+charm run . --docker --input "hello"
 ```
 
-Then configure the custom image in `charm.yaml`:
+## Related
 
-```yaml
-runtime:
-  custom_image: "ghcr.io/your-org/your-custom-runtime:latest"
-  adapter:
-    type: ag2
-    entry_point: src.main:my_agent
-```
-
-With this setup, the Cloud Runner will boot your custom image, read `type: ag2`, dynamically load your adapter via the Python entry point, and execute the agent flawlessly.
+- [Extensibility Overview](/guides/extensibility)
+- [Custom Runtimes](/guides/custom-runtimes)
+- [Custom Python Adapter](/adapters/custom) — built-in path, no entry points
+- [Write a Custom Adapter](/oss/adapter) — contributing official adapters to the SDK repo

--- a/docs/guides/custom-runtimes.mdx
+++ b/docs/guides/custom-runtimes.mdx
@@ -1,66 +1,105 @@
 ---
 title: Custom Runtimes
-description: Learn how to provide your own Docker image for complete control over your agent's execution environment.
+description: Provide your own Docker image for agent execution on the cloud runner.
 ---
 
 # Custom Runtimes
 
-While Charm provides highly optimized base images for standard frameworks like LangChain, CrewAI, and OpenClaw, you may sometimes need complete control over the execution environment. 
+Use a **custom runtime** when the official Charm base images are not enough — extra system packages, pre-baked models, a private fork of `charmos`, or a **third-party adapter/telemetry/memory plugin** baked into the image.
 
-This could be because:
-- You are using a specialized framework like AG2 or AutoGen.
-- You have heavy system dependencies (e.g., custom rendering engines, specific versions of Node.js).
-- You want to pre-install massive ML models inside the image to save boot time.
+`runtime.custom_image` tells the cloud runner which container image to pull. When set, it **overrides** the default adapter→image mapping from [Base Images](/platform/base-images).
 
-Charm allows you to define a **Custom Runtime** by pointing to your own Docker image.
+## When you need this
+
+| Goal | Typical setup |
+|------|----------------|
+| Extra Python/system deps only | `type: custom` + `custom_image` |
+| Third-party adapter plugin | `type: your_plugin` + `custom_image` with plugin installed |
+| Telemetry or memory plugin on cloud | Same — plugin package must be in the image |
+| Private or pinned `charmos` version | Extend base image and install your SDK build |
+
+You do **not** need `custom_image` for a normal `charm init` Python agent that runs on the default `runner-base` image.
 
 ## 1. Create a Dockerfile
 
-To ensure compatibility with the Charm Runner, we highly recommend extending the official base image: `ghcr.io/charmaios/charm-base:latest`.
+Extend the official base image:
 
 ```dockerfile
-# Start from the minimal Charm Base Image
 FROM ghcr.io/charmaios/charm-base:latest
 
-# Example: Install system dependencies
-RUN apt-get update && apt-get install -y ffmpeg
+# System dependencies (example)
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
 
-# Example: Install your custom framework
-RUN uv pip install charm-adapter-ag2
-
-# You can also pre-download models or copy proprietary binaries here
+# Third-party plugin packages (examples)
+RUN uv pip install charm-adapter-ag2 charm-telemetry-datadog
 ```
 
-Build and push this image to a container registry accessible to the internet (e.g., GitHub Container Registry, Docker Hub, or Google Artifact Registry).
+Build and push to a registry the runner can reach:
 
 ```bash
-docker build -t ghcr.io/your-org/my-agent-image:latest .
-docker push ghcr.io/your-org/my-agent-image:latest
+docker build -t ghcr.io/your-org/my-agent-runtime:prod .
+docker push ghcr.io/your-org/my-agent-runtime:prod
 ```
 
-## 2. Declare the Custom Image in `charm.yaml`
+For Google Artifact Registry:
 
-Once your image is publicly accessible, you can tell the Charm Cloud Runner to use it by adding the `custom_image` field under the `runtime` configuration block in your `charm.yaml`:
+```bash
+gcloud auth configure-docker us-central1-docker.pkg.dev
+docker tag ghcr.io/your-org/my-agent-runtime:prod \
+  us-central1-docker.pkg.dev/YOUR_PROJECT/charm-images/my-agent-runtime:prod
+docker push us-central1-docker.pkg.dev/YOUR_PROJECT/charm-images/my-agent-runtime:prod
+```
+
+## 2. Declare the image in `charm.yaml`
 
 ```yaml
-version: "{manifest_version}"
+version: "0.4.2"
+
 persona:
   name: "My Custom Agent"
+  description: "Runs on a custom runtime image"
+  version: "0.1.0"
+
+interface:
+  input:
+    type: object
+    required: [input]
+    properties:
+      input: { type: string }
+  output:
+    type: string
 
 runtime:
+  custom_image: "ghcr.io/your-org/my-agent-runtime:prod"
   adapter:
-    type: "custom"
-    entry_point: "src.main:run"
-  
-  # Inject your custom image URI here
-  custom_image: "ghcr.io/your-org/my-agent-image:latest"
+    type: custom
+    entry_point: src.main:agent
+  lifecycle: serverless
 ```
 
-## 3. Deployment
+The runner bundles your **agent source code** at execute time; the **image** supplies the environment (Python deps, plugins, system libs).
 
-Simply run `charm push` as usual.
+## 3. Publish and run
 
-The Charm CLI will bundle your code and update the registry. When users trigger your agent, the Cloud Runner will dynamically fetch and launch `ghcr.io/your-org/my-agent-image:latest` instead of the default images, giving your agent the exact environment it needs.
+```bash
+charm validate .
+charm push .
+```
 
-> [!NOTE]
-> Ensure your Docker Registry is public, or that the Charm Cloud Runner has the necessary IAM permissions/Service Accounts configured to pull from your private registry.
+Users trigger runs from the Store; the runner pulls `custom_image` and executes your bundle inside that container.
+
+## Registry access
+
+| Registry visibility | Requirement |
+|--------------------|-------------|
+| Public (GHCR public, etc.) | Runner pulls without extra IAM |
+| Private | Grant the cloud runner service account **read** access to your registry |
+
+The runner does **not** run `pip install` for your agent or plugins after the container starts — everything required at runtime must be in the image (except the agent bundle mounted/downloaded by the runner).
+
+## Related
+
+- [Extensibility Overview](/guides/extensibility)
+- [Custom Adapters](/guides/custom-adapters)
+- [Base Images](/platform/base-images)

--- a/docs/guides/extensibility.mdx
+++ b/docs/guides/extensibility.mdx
@@ -1,0 +1,78 @@
+---
+title: Extensibility Overview
+description: How to extend Charm — adapters, runtimes, telemetry, memory, UI, templates, and renderers.
+---
+
+# Extensibility Overview
+
+Charm separates a **small stable core** from **community-owned extensions**. Not every extension works the same way — some are runtime Python plugins, some are store contributions, and some are manifest PRs.
+
+Use this page to pick the right path before you start building.
+
+## Extension paths at a glance
+
+| What you want to add | Registration | Runs where | Needs `custom_image` on cloud? | Needs store deploy? |
+|----------------------|--------------|------------|----------------------------------|---------------------|
+| [Custom adapter plugin](/guides/custom-adapters) | `charm.adapters` entry point | Agent container | **Yes** | No |
+| [Custom runtime only](/guides/custom-runtimes) | `runtime.custom_image` in YAML | Agent container | **Yes** | No |
+| [Telemetry exporter](/guides/telemetry-exporters) | `charm.telemetry` entry point | Agent container | **Yes** | No |
+| [Memory backend](/guides/state-and-memory) | `charm.memory` entry point | Agent container | **Yes** (if not built-in) | No |
+| [Input form widgets](/guides/interface) | `interface.ui` in YAML | Store UI | No | Only for **new** widget types |
+| [Output renderers](/guides/output-renderers) | `_charm_render_type` in agent output | Store UI | No | Only for **new** renderer types |
+| [Starter templates](/guides/community-templates) | PR to `templates-manifest.json` | `charm init` | No | No (manifest merge) |
+
+## Two kinds of “custom” (important)
+
+These names overlap — they are **not** the same thing:
+
+| Term | Meaning |
+|------|---------|
+| **`runtime.adapter.type: custom`** | Built-in Charm adapter for plain Python agents (`CharmCustomAdapter` in core). Good default for `charm init` projects. |
+| **`runtime.custom_image`** | Docker image override for the cloud runner. Required for third-party adapter/telemetry/memory plugins. |
+| **Third-party adapter plugin** | New adapter name (e.g. `ag2`, `plugin_test`) registered via `[project.entry-points."charm.adapters"]`. |
+
+Scenario: you can use **`type: custom`** with **`custom_image`** (extra deps, no new adapter class).  
+Scenario: you can use **`type: ag2`** with **`custom_image`** (new adapter plugin + image that installs it).
+
+## Recommended workflow for plugin authors
+
+1. **Start from a normal agent** — `charm init my-agent --template python`
+2. **Add a pip package** with your adapter/telemetry/memory classes and `pyproject.toml` entry points
+3. **Point `charm.yaml` at your plugin** — `runtime.adapter.type: your_plugin_name`
+4. **Build a Docker image** that installs your package (and compatible `charmos`) — see [Custom Runtimes](/guides/custom-runtimes)
+5. **Set `runtime.custom_image`** to that image URI
+6. **`charm validate`** → **`charm push`** → run on the Store
+
+The cloud runner **does not `pip install` your plugin at runtime**. Your package must already be in the container image.
+
+## Built-in vs third-party
+
+| Layer | Built-in (no plugin package) | Third-party (plugin author) |
+|-------|------------------------------|-----------------------------|
+| Python agent logic | `charm init` + `type: custom` | Same |
+| Adapter type | `custom`, `langchain`, `openclaw`, … | New name via entry points |
+| Runtime image | Official `runner-*` images | Your `custom_image` |
+| Store form widgets | `text`, `textarea`, `file` | New widgets → store PR |
+| Rich output UI | Built-in `_charm_render_type` values | New types → store PR |
+
+## Cloud prerequisites
+
+For any **custom image** on production:
+
+1. Push the image to a registry the runner can pull (Artifact Registry, GHCR, etc.)
+2. Grant the runner service account **read** access to that registry (if private)
+3. Declare `runtime.custom_image` in `charm.yaml` — the runner selects it over default adapter images
+
+See [Base Images](/platform/base-images) and [Custom Runtimes](/guides/custom-runtimes).
+
+## Next steps
+
+- [Custom Adapters](/guides/custom-adapters) — third-party framework integration
+- [Custom Runtimes](/guides/custom-runtimes) — Docker image overrides
+- [Telemetry Exporters](/guides/telemetry-exporters)
+- [State & Memory](/guides/state-and-memory)
+- [Input Forms (UI Schema)](/guides/interface)
+- [Output Renderers](/guides/output-renderers)
+- [Community Templates](/guides/community-templates)
+
+For core contributors merging adapters into the official SDK, see [Write a Custom Adapter](/oss/adapter) (in-repo process).

--- a/docs/guides/interface.mdx
+++ b/docs/guides/interface.mdx
@@ -1,83 +1,85 @@
 ---
 title: How to Build Input Forms (UI Schema)
-summary: A practical guide to configuring dynamic input forms for your agent.
+summary: Configure dynamic input forms for your agent in the Charm Store.
 ---
 
-The `interface` block in your `charm.yaml` generates the input form users see in the Charm Store. 
+The `interface` block in `charm.yaml` defines the JSON Schema for user inputs. The optional `interface.ui` block maps fields to Store form widgets.
 
-For the complete list of supported schema fields, please check the [Manifest Reference](/references/manifest).
+For all manifest fields, see the [Manifest Reference](/references/manifest).
 
-## How to Create Text Inputs
-
-You can easily request strings from the user. 
+## Text inputs
 
 ```yaml
 interface:
   input:
-    type: "object"
-    required: ["message"]
+    type: object
+    required: [message]
     properties:
       message:
-        type: "string"
-        title: "Message"
-        description: "What should the agent do?"
+        type: string
+        title: Message
+        description: What should the agent do?
+  output:
+    type: string
 ```
 
-## How to Add Validation Rules
-
-To prevent users from submitting invalid data, use JSON schema constraints:
+## Validation rules
 
 ```yaml
       depth:
-        type: "integer"
-        title: "Search Depth"
+        type: integer
+        title: Search Depth
         default: 3
         minimum: 1
         maximum: 5
 ```
 
-## How to Assign Custom UI Widgets
+## Built-in UI widgets
 
-The `ui` block maps your data fields to specific frontend React components. This keeps your data schema clean while allowing rich UI.
+Map fields to Store components with `interface.ui`:
 
 ```yaml
   ui:
-    # Render a large multi-line text input
     message: { "ui:widget": "textarea" }
-    
-    # Render a secure masked input
-    api_key: { "ui:widget": "password" }
-    
-    # Render a file upload zone. 
-    # (The runner will automatically inject the uploaded filename here)
-    document: { "ui:widget": "file" }
-    
-    # Render a color picker
-    brand_color: { "ui:widget": "color" }
+    upload: { "ui:widget": "file" }
 ```
 
-## How to Access Inputs in Code
+**Supported built-in widgets today:**
 
-The values submitted by the user are passed to your agent as a dictionary. 
+| Widget | Description |
+|--------|-------------|
+| `text` | Single-line input (default) |
+| `textarea` | Multi-line input |
+| `file` | File upload — runner receives the uploaded file path in inputs |
+
+Legacy templates may use `x-ui-widget` on individual properties; the Store still resolves those for backward compatibility.
+
+Unknown widget names fall back to `text`.
+
+## Access inputs in code
 
 ```python
 def agent(inputs):
-    # Fetch the input exactly as named in the schema
     message = inputs.get("message")
-    search_depth = inputs.get("depth", 3)
+    depth = inputs.get("depth", 3)
+    return f"Processed: {message} (depth={depth})"
 ```
 
-## For Platform Contributors: Adding New Widgets
+File fields are injected by the runner/store pipeline — use the key name from your schema.
 
-If you are contributing to the Charm platform and want to support a new widget type (e.g., a map selector), you do not need to modify the core `uac` (Universal Agent Contract). The UI schema is decoupled via a `WidgetRegistry` in the frontend application (`charm-store`).
+## Adding new widget types (platform contributors)
 
-**How to add a new widget:**
-1. **Create the Component:** Build a new standard React component in `charm-store/app/components/` that accepts standard props (such as `value` and `onChange`).
-2. **Register the Component:** Open `charm-store/app/components/DynamicForm.tsx` and add your new component to the `WidgetRegistry`:
-   ```tsx
-   const WidgetRegistry: Record<string, React.FC<WidgetProps>> = {
-       "textarea": TextareaWidget,
-       "map-selector": MapSelectorWidget, // Your new widget
-   };
-   ```
-3. **Update Documentation:** Add the new widget name to the supported list in the Reference so Agent Creators know they can use it.
+New widgets are **not** runtime plugins. They require a **charm-store** change and deploy:
+
+1. Create a React field component (accepts `value`, `onChange`, etc.)
+2. Register it in `WidgetRegistry` inside `charm-store/app/components/DynamicForm.tsx`
+3. Document the widget name here and in [UI Protocol](/platform/ui-protocol)
+4. Deploy the store
+
+Agent authors can then reference the new name in `interface.ui`.
+
+## Related
+
+- [Extensibility Overview](/guides/extensibility)
+- [UI Protocol Reference](/platform/ui-protocol)
+- [Output Renderers](/guides/output-renderers)

--- a/docs/guides/output-renderers.mdx
+++ b/docs/guides/output-renderers.mdx
@@ -1,110 +1,119 @@
 ---
 title: How to Render Rich UI
-description: A guide on returning structured data from your agent to render rich UI components in the Charm Store.
+description: Return structured data from your agent to render charts and components in the Charm Store.
 ---
 
 # How to Render Rich UI
 
-The Charm Store features a **Universal Renderer** that can automatically transform your agent's data into beautiful, interactive React components—like charts, data grids, and metric cards—without you needing to write any frontend code.
+The Charm Store **Universal Renderer** maps structured agent output to React components — bar/line/pie charts, data grids, metric cards — without you writing frontend code.
 
-This guide will show you how to structure your agent's return values to trigger these components.
+For full payload schemas, see the [UI Protocol Reference](/platform/ui-protocol).
 
-For a full list of supported UI schemas, please refer to the [UI Protocol Reference](/platform/ui-protocol).
+## Built-in render types (no store changes)
 
-## Returning Explicit UI Components
+Return a JSON object with `_charm_render_type` set to one of:
 
-To guarantee that the Store renders a specific component, your agent should return a Python dictionary containing the special key `_charm_render_type`. 
+| Type | Use case |
+|------|----------|
+| `bar_chart` | Categorical comparisons |
+| `line_chart` | Trends over time |
+| `pie_chart` | Part-to-whole |
+| `data_grid` | Tabular results |
+| `metric_card` | KPI-style metrics |
 
-### Using the Custom Adapter
+These work for any published agent — **no store deploy required**.
 
-If you are writing a standard Python function agent, you can simply return the dictionary:
+## Custom Python agents
 
 ```python
 def agent(inputs):
-    # Perform your agent logic here...
-    
-    # Return a structured dictionary instead of a string
     return {
         "_charm_render_type": "bar_chart",
         "title": "Quarterly Sales",
         "data": [
             {"name": "Q1", "value": 15000},
             {"name": "Q2", "value": 22000},
-            {"name": "Q3", "value": 31000}
-        ]
+        ],
     }
 ```
 
-### Using Framework Adapters (LangChain, CrewAI, OpenClaw)
+With the built-in **`custom`** adapter, return the dict directly from your entry point. With a third-party adapter, return `{"status": "success", "output": {...}}` or ensure your adapter forwards structured output.
 
-If you are using a framework, you can configure your LLM to output a JSON string that matches the required schema. The Charm adapters will automatically detect the JSON, parse it, and forward the structure to the UI.
+## Framework adapters (LangChain, CrewAI, OpenClaw)
 
-For example, using OpenClaw:
+Configure the model to emit JSON matching the schema. Example for OpenClaw:
 
 ```yaml
-# Inside charm.yaml
 runtime:
   adapter:
     type: openclaw
   config:
     system_prompt: |
-      You are a data analysis agent. 
-      You MUST return your final answer as a JSON object containing a pie chart.
-      Format:
+      Return your final answer as JSON only:
       {
-        "_charm_render_type": "pie_chart",
-        "title": "Data Distribution",
-        "data": [{"name": "A", "value": 50}, {"name": "B", "value": 50}]
+        "_charm_render_type": "metric_card",
+        "title": "Analysis Results",
+        "metrics": [
+          {"label": "Confidence", "value": "98.5", "unit": "%"}
+        ]
       }
 ```
 
-## Rendering Custom UI with HTML/SVG
+Adapters parse JSON final messages and forward structure to the Store.
 
-If the built-in components do not meet your needs, you can return raw HTML or SVG strings. The Store's Markdown renderer safely sanitizes HTML (stripping `<script>` tags) and renders it directly.
+## Metric card example
+
+```python
+return {
+    "_charm_render_type": "metric_card",
+    "title": "Performance",
+    "metrics": [
+        {"label": "Active Users", "value": 1204, "change": 12, "unit": "users"},
+        {"label": "Error Rate", "value": "0.3", "unit": "%"},
+    ],
+}
+```
+
+## Markdown and HTML fallback
+
+Return a plain string for standard Markdown rendering. HTML and SVG snippets are sanitized (scripts stripped):
 
 ```python
 def agent(inputs):
-    # Dynamically generate an SVG badge
-    status = "Operational"
-    color = "#4CAF50"
-    
-    svg_badge = f"""
-    <svg width="150" height="30" xmlns="http://www.w3.org/2000/svg">
-      <rect width="150" height="30" rx="5" fill="{color}"/>
-      <text x="75" y="20" font-family="sans-serif" font-size="14" fill="white" text-anchor="middle">
-        {status}
-      </text>
-    </svg>
-    """
-    
-    # You can mix SVG with standard Markdown
-    return f"### System Status\n\n{svg_badge}"
+    return "### Status\n\nAll systems operational."
 ```
 
-## Mixing Text and UI
+## Streaming text + rich final
 
-In most conversational agents, you want to stream thoughts and text before showing the final chart. 
-
-To achieve this, use the `CharmEmitter` to stream markdown text during the execution, and then return the rich JSON object as the final result:
+Use `CharmEmitter` for intermediate markdown, then return structured JSON as the final result:
 
 ```python
 from charm.core.io import CharmEmitter
 
 def agent(inputs):
-    CharmEmitter.emit_delta("Analyzing the dataset...\n")
-    # ... logic ...
-    CharmEmitter.emit_delta("Generating the chart...\n")
-    
+    CharmEmitter.emit_delta("Analyzing dataset...\n")
     return {
         "_charm_render_type": "metric_card",
-        "title": "Analysis Results",
-        "metrics": [
-            {"label": "Confidence", "value": "98.5", "unit": "%"}
-        ]
+        "title": "Results",
+        "metrics": [{"label": "Score", "value": 98, "unit": "%"}],
     }
 ```
 
-## Next Steps
+## Adding **new** renderer types (platform contributors)
 
-- Explore all supported JSON shapes in the [UI Protocol Reference](/platform/ui-protocol).
-- Learn about [Execution Modes](/platform/execution-modes) to understand how data streams to the frontend.
+Built-in types are registered in the **charm-store** app at build time (`registerRenderer` in `CharmRenderers.tsx`). There is **no runtime npm plugin loader** today.
+
+To add a new component type:
+
+1. Implement a React renderer in `charm-store`
+2. Call `registerRenderer("my_type", ...)` 
+3. Deploy the store
+4. Document the JSON schema in [UI Protocol](/platform/ui-protocol)
+
+Agent authors can then use `"_charm_render_type": "my_type"` after that deploy.
+
+## Related
+
+- [UI Protocol Reference](/platform/ui-protocol)
+- [Extensibility Overview](/guides/extensibility)
+- [Input Forms (UI Schema)](/guides/interface)

--- a/docs/guides/overview.mdx
+++ b/docs/guides/overview.mdx
@@ -60,3 +60,7 @@ See [Publishing](/guides/push).
 ## 7. Observe
 
 Use Store, Studio, and CLI logs to inspect production behavior.
+
+## Extending Charm
+
+For adapters, runtimes, telemetry, memory, UI, templates, and renderers, start with [Extensibility Overview](/guides/extensibility).

--- a/docs/guides/state-and-memory.mdx
+++ b/docs/guides/state-and-memory.mdx
@@ -1,100 +1,113 @@
 ---
 title: Custom Memory Storage
-description: Learn how to persist your agent's memory and state to Redis, Postgres, or other external databases.
+description: Persist agent memory and state with pluggable storage backends.
 ---
 
 # State & Memory Storage
 
-By default, Charm persists your agent's memory and state using the local filesystem (which the Charm Cloud Runner automatically syncs to a Google Cloud Storage bucket). 
+By default, Charm uses **local file-backed memory** (`runtime.memory.provider: local`). On the cloud runner, workspace files are persisted under a managed workspace path (backed by cloud storage for serverless/daemon workloads).
 
-However, if you are self-hosting your agents, or if you require an enterprise database like Redis or PostgreSQL for horizontal scaling and faster state retrieval, you can swap out the default memory provider by installing and configuring a **Memory Storage Plugin**.
+For Redis, PostgreSQL, or other backends, install a **memory plugin** or use the built-in `supabase` provider where configured.
 
-## Configuring a Memory Provider
-
-To use an external memory provider, specify it in your `charm.yaml` file under the `runtime.memory` section.
+## Configuring a provider
 
 ```yaml
 runtime:
   adapter:
-    type: langgraph
+    type: langchain
+    entry_point: src.main:agent
   memory:
     provider: redis
     config:
       url: "redis://localhost:6379/0"
 ```
 
-## Creating a Custom Memory Plugin
+The cloud runner sets `CHARM_MEMORY_PROVIDER` from this block so runtime code can resolve the active backend.
 
-If a plugin for your database doesn't exist yet, you can easily build one. Just like adapters and telemetry exporters, Memory Storage plugins are discovered dynamically using Python `entry_points`.
+Built-in provider names today:
+
+| Provider | Source |
+|----------|--------|
+| `local` (default) | Core — file-backed |
+| `supabase` | Core — when Supabase memory is configured |
+| Custom names | `charm.memory` entry points |
+
+## Creating a memory plugin
 
 ### 1. Implement `BaseMemoryStore`
 
-Create a new Python class that inherits from `charm.core.storage.BaseMemoryStore`.
-
 ```python
 from typing import Any, Dict, List
-from charm.core.storage import BaseMemoryStore
-import redis
 import json
+import redis
+from charm.core.storage import BaseMemoryStore
 
 class RedisMemory(BaseMemoryStore):
     def __init__(self, config: Dict[str, Any]):
         super().__init__(config)
-        # Initialize connection using the config from charm.yaml
-        redis_url = self.config.get("url", "redis://localhost:6379/0")
-        self.client = redis.Redis.from_url(redis_url)
+        self.client = redis.Redis.from_url(
+            self.config.get("url", "redis://localhost:6379/0")
+        )
 
     def load_messages(self, thread_id: str) -> List[Dict[str, Any]]:
-        raw_data = self.client.get(f"charm:memory:{thread_id}")
-        if raw_data:
-            return json.loads(raw_data)
-        return []
+        raw = self.client.get(f"charm:memory:{thread_id}")
+        return json.loads(raw) if raw else []
 
     def save_messages(self, thread_id: str, messages: List[Dict[str, Any]]) -> None:
         self.client.set(f"charm:memory:{thread_id}", json.dumps(messages))
 
     def get_langgraph_checkpointer(self) -> Any:
-        # If your agent uses LangGraph, you can optionally return a BaseCheckpointSaver
-        # from the langgraph package.
         return None
 ```
 
-### 2. Register the Plugin
-
-In your package's `pyproject.toml`, add an entry to the `charm.memory` group:
+### 2. Register via entry points
 
 ```toml
 [project.entry-points."charm.memory"]
-redis = "charm_memory_redis.plugin:RedisMemory"
+redis = "charm_memory_redis.store:RedisMemory"
 ```
 
-When you install this package (`pip install .`), the Charm Runner will automatically discover the `redis` provider name and use it when configured in `charm.yaml`.
+### 3. Use in `charm.yaml`
 
-## Using Memory in Custom Adapters
+```yaml
+runtime:
+  memory:
+    provider: redis
+    config:
+      url: "${REDIS_URL}"
+```
 
-If you are writing a custom adapter or a standard Python agent and need to manually read or save the conversation history, you can access the active memory provider via the `StorageManager`:
+## Using memory from agent code
 
 ```python
+import os
 from charm.core.storage import StorageManager
 
 def agent(inputs):
     thread_id = inputs.get("__charm_thread_id__", "default")
-    
-    # Retrieves the active provider (e.g., RedisMemory, if configured)
-    memory_store = StorageManager.get_provider("local", {}) 
-    
-    # Load previous history
-    history = memory_store.load_messages(thread_id)
-    
-    # ... logic ...
-    
-    # Save updated history
-    history.append({"role": "assistant", "content": "Hello!"})
-    memory_store.save_messages(thread_id, history)
-    
-    return "Hello!"
+    provider = os.getenv("CHARM_MEMORY_PROVIDER", "local")
+
+    store = StorageManager.get_provider(provider, {})
+    history = store.load_messages(thread_id)
+
+    history.append({"role": "user", "content": str(inputs)})
+    store.save_messages(thread_id, history)
+
+    return {"status": "success", "output": f"Turns: {len(history)}"}
 ```
 
-## Cloud Runner Considerations
+`StorageManager` caches the active provider for the process. Pass the same `config` dict shape as `runtime.memory.config` when constructing plugins that need connection settings.
 
-When deploying to the Charm Cloud Runner, if your `charm.yaml` defines a custom memory provider like `redis`, the Runner will **skip** mounting the default GCS storage bucket. Instead, your agent container will boot immediately and connect directly to your external database, which can significantly reduce cold start times.
+## Cloud deployment
+
+1. Install your memory plugin in **`runtime.custom_image`** (unless using built-in `local` or `supabase`)
+2. Ensure **`policies.allow_internet_access`** (or network policy) allows reaching your database
+3. Provide connection secrets via environment variables — not in committed `charm.yaml`
+
+If the configured plugin is not found at runtime, Charm **falls back to local file memory** and logs a warning.
+
+## Related
+
+- [Extensibility Overview](/guides/extensibility)
+- [Custom Runtimes](/guides/custom-runtimes)
+- [Threads](/platform/threads)

--- a/docs/guides/telemetry-exporters.mdx
+++ b/docs/guides/telemetry-exporters.mdx
@@ -1,30 +1,27 @@
 ---
 title: Telemetry Exporters
-description: Learn how to monitor and observe your Charm Agents by integrating custom telemetry exporters.
+description: Monitor agent lifecycle by registering custom telemetry exporter plugins.
 ---
 
 # Telemetry Exporters
 
-Charm provides an open observability framework to track the full lifecycle of your agents—from LLM token generation to tool execution and error handling. 
+Charm dispatches execution lifecycle events (run start/end, tool calls, LLM tokens, errors) to a **`TelemetryManager`** inside the agent container. By default, events stream to stdout for the cloud runner to forward as SSE. You can add **custom exporters** to forward the same events to Datadog, LangSmith, Sentry, etc.
 
-By default, Charm streams execution events via `stdout` so the Charm Cloud Runner can capture and broadcast them to end-users via Server-Sent Events (SSE). However, you can extend this by building and registering **Custom Telemetry Exporters** to forward events directly to external platforms like DataDog, LangSmith, or Sentry.
+> Telemetry plugins run **inside the agent container**, not in the store or cloud-runner API process.
 
-## 1. Create your Telemetry Exporter
+## 1. Implement `BaseTelemetryExporter`
 
-To create a custom telemetry exporter, create a new Python class that inherits from `charm.core.telemetry.BaseTelemetryExporter`. You can implement whichever lifecycle hooks you need:
-
-Create a file named `my_exporter.py`:
+Subclass `charm.core.telemetry.BaseTelemetryExporter`. **All abstract hook methods must be implemented** (use `pass` for hooks you do not need):
 
 ```python
 import os
-from typing import Dict, Any
+from typing import Any, Dict
 from charm.core.telemetry import BaseTelemetryExporter
 
 class DataDogExporter(BaseTelemetryExporter):
-    def __init__(self):
-        # API Keys can be securely injected via environment variables
-        self.api_key = os.getenv("DATADOG_API_KEY")
-        
+    def __init__(self) -> None:
+        self.api_key = os.getenv("DATADOG_API_KEY", "")
+
     def on_run_start(self, run_id: str, inputs: Dict[str, Any]) -> None:
         pass
 
@@ -35,7 +32,6 @@ class DataDogExporter(BaseTelemetryExporter):
         pass
 
     def on_tool_start(self, tool_name: str, input_str: str) -> None:
-        # e.g., send a custom Datadog metric
         pass
 
     def on_tool_end(self, tool_name: str, output: str) -> None:
@@ -51,34 +47,49 @@ class DataDogExporter(BaseTelemetryExporter):
         pass
 ```
 
-## 2. Register via Entry Points
-
-Just like custom adapters, Charm discovers telemetry exporters dynamically using Python `entry_points`.
-
-In your package's `pyproject.toml`, add an entry to the `charm.telemetry` group:
+## 2. Register via entry points
 
 ```toml
 [project.entry-points."charm.telemetry"]
-datadog = "charm_telemetry_datadog.my_exporter:DataDogExporter"
+datadog = "charm_telemetry_datadog.exporter:DataDogExporter"
 ```
 
-Once installed, Charm's `TelemetryManager` will recognize the `datadog` plugin.
+## 3. Opt in from `charm.yaml`
 
-## 3. Enable it in `charm.yaml`
-
-To avoid loading unnecessary plugins, telemetry exporters are **opt-in**. You must explicitly list the exporters you want to activate in your `charm.yaml` configuration file:
+Exporters are **opt-in** — list the entry point **names** you want loaded:
 
 ```yaml
 runtime:
   adapter:
-    type: python
-    entry_point: src.main:my_agent
+    type: custom
+    entry_point: src.main:agent
   telemetry:
     - datadog
 ```
 
-## 4. Deploying to the Cloud Runner
+The default `CharmEmitterExporter` always runs; listed plugins are added to the dispatch list.
 
-When deploying your agent to the Charm Cloud Runner, ensure that:
-1. You provide a **Custom Image** (`custom_image`) that installs your telemetry python package (e.g., `RUN uv pip install charm-telemetry-datadog`).
-2. You provide the required secrets (e.g., `DATADOG_API_KEY`) via your Agent's Environment Variables settings in the Charm Dashboard. The runner will securely inject these directly into the container execution context.
+## 4. Cloud deployment
+
+1. **Install the exporter package in your `custom_image`** — same requirement as [Custom Adapters](/guides/custom-adapters)
+2. **Inject secrets via environment variables** (e.g. `DATADOG_API_KEY`) through the Store agent settings or runner env resolution — never hard-code keys in `charm.yaml`
+
+```dockerfile
+FROM ghcr.io/charmaios/charm-base:latest
+RUN uv pip install charm-telemetry-datadog
+```
+
+```yaml
+runtime:
+  custom_image: "ghcr.io/your-org/my-runtime:prod"
+  telemetry:
+    - datadog
+```
+
+View exporter output in **container logs** (Cloud Run / Docker), not in Store SSE unless your exporter also writes via `CharmEmitter`.
+
+## Related
+
+- [Extensibility Overview](/guides/extensibility)
+- [Observability](/platform/observability)
+- [Custom Runtimes](/guides/custom-runtimes)

--- a/docs/oss/adapter.mdx
+++ b/docs/oss/adapter.mdx
@@ -1,41 +1,43 @@
 ---
 title: Write a Custom Adapter
-summary: Build and contribute a new agent framework adapter for Charm.
+summary: Contribute an adapter to the official Charm SDK repository.
 ---
 
-Adapters let Charm support different agent frameworks behind a shared runner interface.
+Adapters connect agent frameworks to Charm's runner protocol (`invoke`, streaming, tools, errors).
 
-## When to Add an Adapter
+> **Building a third-party plugin without forking Charm?** See [Custom Adapters](/guides/custom-adapters) (entry points + custom image). This page is for **core contributors** adding official adapters to the `charmos` package.
 
-Add an adapter when a framework has a distinct execution model that cannot be cleanly handled by the existing adapters.
+## When to add an adapter to core
 
-## Adapter Responsibilities
+Add to the SDK when the framework is widely used and should ship with official runner images and first-class docs. Niche or experimental integrations should stay as **entry-point plugins** in separate packages.
 
-An adapter should define how to:
+## Community plugin path (preferred for most authors)
 
-- load the user's entry point,
-- pass inputs into the framework,
-- stream or return output,
-- surface errors,
-- handle tools or state when supported.
+1. Publish a pip package with `[project.entry-points."charm.adapters"]`
+2. Ship a Docker image with that package installed
+3. Set `runtime.custom_image` + `runtime.adapter.type` in `charm.yaml`
 
-## Development Steps
+No changes to the Charm GitHub repo required.
 
-1. Study the closest existing adapter.
-2. Add the adapter implementation.
-3. Register the adapter type.
-4. Add or update manifest validation.
-5. Add a minimal template or example.
-6. Add tests.
-7. Update docs.
+## Core contributor path
+
+1. Study the closest adapter in `src/charm/adapters/`
+2. Implement `BaseAdapter`
+3. Register in `pyproject.toml` under `[project.entry-points."charm.adapters"]`
+4. Add/update Dockerfile if a dedicated runner image is needed
+5. Add tests and adapter docs under `docs/adapters/`
+6. Update `templates-manifest.json` if a new starter template is warranted
 
 ## Testing
-
-Test locally with:
 
 ```bash
 charm validate path/to/example
 charm run path/to/example --input "Hello"
+charm run path/to/example --docker --input "Hello"
 ```
 
-Use Docker mode if the adapter depends on runtime image behavior.
+## Related
+
+- [Extensibility Overview](/guides/extensibility)
+- [Custom Adapters](/guides/custom-adapters)
+- [Adapter overview](/adapters/overview)

--- a/docs/platform/base-images.mdx
+++ b/docs/platform/base-images.mdx
@@ -32,6 +32,8 @@ runtime:
 
 When `custom_image` is declared, the Cloud Runner completely ignores the adapter mapping and boots your provided Docker image directly.
 
+Third-party adapter plugins (registered via `charm.adapters` entry points) **require** a `custom_image` that installs the plugin package — see [Custom Adapters](/guides/custom-adapters).
+
 > **Note**: The legacy `runtime.mode` configuration (`standard` or `full`) is now deprecated and ignored by the Cloud Runner.
 
 ## Related Pages

--- a/docs/snippets/base-image-mapping.mdx
+++ b/docs/snippets/base-image-mapping.mdx
@@ -1,4 +1,8 @@
-- **Custom / Standard Python** (`type: "custom"`): Uses `runner-base`. A minimal Python environment.
-- **LangChain** (`type: "langchain"`): Uses `runner-langchain`. Pre-installed with LangChain dependencies.
-- **CrewAI** (`type: "crewai"`): Uses `runner-crewai`. Pre-installed with CrewAI dependencies.
-- **OpenClaw** (`type: "openclaw"`): Uses `runner-openclaw`. A heavy environment that includes browser automation (Playwright), FFmpeg, and the OpenClaw engine.
+- **Custom / Python** (`type: "custom"` or `"python"`): Uses `runner-base`. Minimal Python environment for plain code agents.
+- **LangChain** (`type: "langchain"`): Uses `runner-langchain`.
+- **LangGraph** (`type: "langgraph"`): Uses `runner-langchain` (same image as LangChain).
+- **CrewAI** (`type: "crewai"`): Uses `runner-crewai`.
+- **OpenClaw** (`type: "openclaw"`): Uses `runner-openclaw` (Playwright, FFmpeg, OpenClaw engine).
+- **Third-party adapter plugins**: Use whatever image you declare in `runtime.custom_image` — the runner does not map plugin names automatically.
+
+When `runtime.custom_image` is set, adapter→image mapping is **ignored** and your URI is used directly.

--- a/src/charm/cli/commands/push.py
+++ b/src/charm/cli/commands/push.py
@@ -269,13 +269,14 @@ def push_command(
             resp_data = reg_resp.json()
             agent_url = resp_data.get("url", "N/A")
 
-            # Try auto-copy to clipboard
+            # Try auto-copy to clipboard (optional; missing xclip/wl-clipboard on Linux is OK)
             clipboard_msg = ""
             try:
                 import pyperclip
+
                 pyperclip.copy(agent_url)
                 clipboard_msg = "\n[bold cyan](Copied to clipboard!)[/bold cyan]"
-            except ImportError:
+            except Exception:
                 pass
 
             console.print(


### PR DESCRIPTION
Squash-merge develop onto main to update extensibility docs, CHA-56 guide improvements, and the Linux clipboard fix in charm push without a merge commit (required by branch rules).

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- List commands run, manual validation, screenshots, or explain why tests were not run. -->

## Release Notes

<!--
Release Drafter builds the draft GitHub Release from merged PRs.
Add exactly one user-facing release label unless this PR should be excluded:
release:feature, release:fix, release:breaking, release:security, release:infra, release:docs, release:chore, release:skip.
Use release:major, release:minor, or release:patch only when the default version bump needs overriding.
-->

- Release label:
- User-facing summary:

## Migration / Deploy Notes

<!-- Required for database, infrastructure, secrets, environment variables, runner, or production behavior changes. -->

- Migration required: yes/no
- Deploy order:
- Rollback or mitigation:

## Checklist

- [ ] I updated docs or left a TODO in the relevant docs page.
- [ ] I added or updated tests where appropriate.
- [ ] I checked for secrets, tokens, or private credentials.
- [ ] I noted breaking changes, if any.

